### PR TITLE
Fix \ being treated as a special character

### DIFF
--- a/inline-anki.el
+++ b/inline-anki.el
@@ -267,7 +267,7 @@ Otherwise, return nil."
                                       "::"
                                       (funcall inline-anki-occluder truth)))
                                    "}}")
-                           nil nil nil 2))))
+                           nil t nil 2))))
       (if (and (= n 0) (not (string-match-p "{{c[1234567890]+::" text)))
           nil ;; Nil signals that no clozes found
         (string-trim (buffer-string))))))


### PR DESCRIPTION
I was having issues when trying to use this package with latex. My commands like \alpha or \sqrt would error out because the \ .
This changes the argument that is passed to the replace-match function so that the string is unchanged